### PR TITLE
Build smaller docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,9 +10,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
-      - run: |
-          sudo apt-get install aria2
-          aria2c --seed-time=1 --select-file=1 https://sukebei.nyaa.si/download/3914574.torrent -d .
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,34 @@
-FROM python:3.11
+FROM debian:12-slim AS build-venv
 
-WORKDIR /root
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes xz-utils python3 python3-venv && \
+    apt-get clean && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip
 
-ENV content=/root/comiclib watch=False
-EXPOSE 8000
-
-RUN apt-get -y update && apt-get -y install ffmpeg
-
-COPY . /tmp/comiclib
-
-RUN pip install --no-cache-dir -U "/tmp/comiclib[full]"
-RUN pip install --no-cache-dir -U gunicorn
-
+ADD https://files.niconi.org/api_dump.sqlite.7z /tmp
+ADD https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-linux-x64 /usr/bin/ffmpeg
 ADD https://www.7-zip.org/a/7z2301-linux-x64.tar.xz /tmp/
-RUN tar -C /usr/bin/ -xvf /tmp/7z*.tar.xz 7zz
+RUN tar -C /usr/bin -xvf /tmp/7z*.tar.xz 7zz
+RUN mkdir /exract
+WORKDIR /extract
+RUN 7zz x /tmp/api_dump.sqlite.7z
+COPY . /tmp/comiclib
+RUN /venv/bin/pip install --no-cache-dir -U "/tmp/comiclib[full]"
+RUN /venv/bin/pip install --no-cache-dir -U gunicorn
+RUN mkdir /userdata 
+# RUN rm -r /tmp/*
 
-# Please download through BitTorrent yourself.
-RUN 7zz x /tmp/comiclib/e-hentai_*/api_dump.sqlite.7z
-RUN rm -r /tmp/*
-
-RUN python3 -c "from comiclib import frontend_boost"
-
-VOLUME /root
-
-CMD [ "gunicorn", "comiclib.main:app", "--worker-class", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "--preload", "--workers", "4" ]
+FROM gcr.io/distroless/python3-debian12 
+COPY --from=build-venv /venv                            /venv
+COPY --from=build-venv /usr/bin/7zz                     /usr/bin
+COPY --from=build-venv /usr/bin/ffmpeg                  /usr/bin
+COPY --from=build-venv /extract/api_dump.sqlite         /data
+COPY --from=build-venv /userdata                        /userdata
+ENV API_DUMP_PATH=/data/api_dump.sqlite content=/root/comiclib watch=False
+EXPOSE 8000
+WORKDIR /userdata
+VOLUME /userdata
+VOLUME /root/comiclib
+RUN [ "/venv/bin/python", "-c", "from comiclib import frontend_boost" ]
+ENTRYPOINT [ "/venv/bin/python", "-m" , "gunicorn", "comiclib.main:app", "--worker-class", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "--preload", "--workers", "4" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ FROM gcr.io/distroless/python3-debian12
 COPY --from=build-venv /venv                            /venv
 COPY --from=build-venv /usr/bin/7zz                     /usr/bin
 COPY --from=build-venv /usr/bin/ffmpeg                  /usr/bin
-COPY --from=build-venv /extract/api_dump.sqlite         /data
+COPY --from=build-venv /extract/api_dump.sqlite         /data/api_dump.sqlite
 COPY --from=build-venv /userdata                        /userdata
-ENV API_DUMP_PATH=/data/api_dump.sqlite content=/root/comiclib watch=False
+ENV importEHdb_API_DUMP_PATH=/data/api_dump.sqlite content=/root/comiclib watch=False
 EXPOSE 8000
 WORKDIR /userdata
 VOLUME /userdata

--- a/comiclib/scanner/30-importEHdb.py
+++ b/comiclib/scanner/30-importEHdb.py
@@ -4,12 +4,12 @@ import sqlite3, re, ast
 from datetime import date
 from pydantic import Field
 from pydantic_settings import BaseSettings
-import os
 
 class Settings(BaseSettings):
     importEHdb_thumb: bool = True
     importEHdb_matchtitle: Union[bool, str] = Field(default=True, union_mode='left_to_right')
     importEHdb_matchtorrent: bool = True
+    importEHdb_API_DUMP_PATH: str = "api_dump.sqlite"
 settings = Settings()
 
 import logging
@@ -39,13 +39,10 @@ class Scanner:
 Currently only support matching by the source URL (from previous scanners).'''
     
     def __init__(self) -> None:
-        # Load database from $API_DUMP_PATH when the environment variable is set
-        # or fallback to api_dump.sqlite in the current directory
-        api_dump_path = os.getenv('API_DUMP_PATH', default="api_dump.sqlite")
-        if Path(api_dump_path).exists():
+        if Path(settings.importEHdb_API_DUMP_PATH).exists():
             logger.info('Loading ehentai metadata database, please wait...')
             # do it in readonly mode, to maintain a readonly container image
-            self.con = sqlite3.connect("file:"+api_dump_path+"?mode=ro", uri=True, check_same_thread=False)
+            self.con = sqlite3.connect("file:"+settings.importEHdb_API_DUMP_PATH+"?mode=ro", uri=True, check_same_thread=False)
             if settings.importEHdb_matchtitle:
                 self.db_title = {blur_title(row[0]): row[1] for row in self.con.execute("SELECT title, gid FROM gallery") if not row[0] is None}
                 self.db_title_jpn = {blur_title(row[0]): row[1] for row in self.con.execute("SELECT title_jpn, gid FROM gallery") if not row[0] is None}

--- a/docs/en/docs/getting-started.md
+++ b/docs/en/docs/getting-started.md
@@ -39,6 +39,7 @@ pip install -U "comiclib[full] @ git+https://github.com/comiclib/comiclib.git"
 ``` bash
 docker run -p 8000:8000 \
 --mount type=bind,source=<YOUR_COMIC_DIRECTORY_HERE>,target=/root/comiclib \
+--mount type=bind,source=<USER_DATA_PATH>,target=/userdata \
 urenko/comiclib
 ```
 ComicLib now runs at http://localhost:8000 .

--- a/docs/zh/docs/getting-started.md
+++ b/docs/zh/docs/getting-started.md
@@ -39,6 +39,7 @@ pip install -U "comiclib[full] @ git+https://github.com/comiclib/comiclib.git"
 ``` bash
 docker run -p 8000:8000 \
 --mount type=bind,source=你的漫画库路径,target=/root/comiclib \
+--mount type=bind,source=你的数据路径,target=/userdata \
 urenko/comiclib
 ```
 现在 ComicLib 运行在了 http://localhost:8000 。


### PR DESCRIPTION
 - Download api_dump.sqlite from CDN (I would be happy to update the file in link, given someone is happy to ping me when upgrading is required)
 - Provide alternative path to load api_dump.sqlite from, to separate userdata from shipped data
 - Load  api_dump.sqlite in RO mode, to prevent creating of WAL file for no use
 - Build smaller images, download size stripped down to ~700 MB and expanded size down to ~1.8GiB (mainly from the api_dump.sqlite)
 - `comiclib_metadata.db` and `thumb` now goes to `/userdata`, should be mounted as seperate mountpoint or volume
 
***
This partally addressed issues in #2, while I did not remove either `7zz` or `api_dump.sqlite`, but tried to stop intermediate files from getting included.
*** 
And we can, potenially, stop shipping  `api_dump.sqlite` within the image, and instruct users to download by their own, then mount it to the image, set `API_DUMP_PATH` environment variable accordingly. This can be done simply by commenting out some lines in `Dockerfile` and updating documentation.

Maybe building 2 different image `:latest` and `:latest-small` would be best, will do if had time.